### PR TITLE
update peerDependencies antd use 4.1.0 or 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "homepage": "https://github.com/crawler-django/virtuallist-antd",
     "peerDependencies": {
-        "antd": "^4.1.0",
+        "antd": "^4.1.0 || ^5.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
使用antd5，npm>=8安装会报错