### PR TITLE
feat: 修复页面在缩放时scrollTop值出现精度问题导致永远小于scrollHeight并且不会触发翻页的BUG

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
     "name": "virtuallist-antd",
     "version": "0.8.0-beta.1",
     "description": "virtualList for antd-table, 实现antd-table的虚拟列表, antd-table无限滚动, infinite scrolling for antd-table",
-    "main": "dist/index.js",
-    "module": "dist/index.es.js",
+    "main": "dist/dist/index.js",
+    "module": "dist/dist/index.es.js",
     "jsnext:main": "dist/index.es.js",
+    "type": "module",
     "engines": {
         "node": ">=8",
         "npm": ">=5"
@@ -40,7 +41,7 @@
         "@babel/preset-env": "^7.9.0",
         "@babel/preset-react": "^7.9.4",
         "@babel/preset-typescript": "^7.16.0",
-        "@svgr/rollup": "^4.3.3",
+        "@svgr/rollup": "^8.1.0",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@types/jest": "^27.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,9 @@ import nested from 'postcss-nested';
 import cssnext from 'postcss-cssnext';
 import cssnano from 'cssnano';
 
-import pkg from './package.json';
+import pkg from "./package.json" assert { type: "json" }
+
+console.log(svgr)
 
 export default {
   input: 'src/index.tsx',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -313,12 +313,13 @@ function VTable(props: any, otherParams): JSX.Element {
             const scrollTop: number = e?.target?.scrollTop ?? 0
             const scrollHeight: number = e?.target?.scrollHeight ?? 0
             const clientHeight: number = e?.target?.clientHeight ?? 0
-
+            const ratio: number = window.devicePixelRatio
+            const precisionScrollTop = ratio === 1 ? scrollTop : Math.ceil(scrollTop)
             // 到底了 没有滚动条就不会触发reachEnd. 建议设置scrolly高度少点或者数据量多点.
-            if (scrollTop === scrollHeight) {
+            if (precisionScrollTop === scrollHeight) {
                 // reachEnd && reachEnd()
             } else if (
-                scrollTop + clientHeight >= scrollHeight &&
+                precisionScrollTop + clientHeight >= scrollHeight &&
                 historyScrollHeight !== scrollHeight
             ) {
                 // 相同的tableData情况下, 上次reachEnd执行后, scrollHeight不变, 则不会再次请求reachEnd


### PR DESCRIPTION
主流浏览器在缩放页面或者分辨率设置百分比缩放时，会导致scrollTop出现浮点精度问题，通过判断devicePixelRatio是否为1,进行向上取整时期大于等于scrollHeight；@svgr/rollup 使其导入兼容ESModule避免打包时报svgr is not a function错误；